### PR TITLE
fix type in README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ run the `hello_world` example as above but in an interactive terminal, run:
 ```bash
 docker run -it --rm \
     -v bazel-cache:/root/.cache/bazel \
-    -v "${MYPROJECT}":/opt/my-project \
+    -v "${MY_PROJECT}":/opt/my-project \
     -w /opt/my-project \
     gcr.io/asylo-framework/asylo
 ```


### PR DESCRIPTION
In the section "Running an interactive terminal",
`MYPROJECT` is used in the example command.  I changed this
to `MY_PROJECT` to be consistent with the rest of the README