### PR TITLE
Fix incorrect SEEK_END for secure_lseek.

### DIFF
--- a/asylo/platform/posix/io/secure_paths.cc
+++ b/asylo/platform/posix/io/secure_paths.cc
@@ -53,7 +53,7 @@ int IOContextSecure::LSeek(off_t offset, int whence) {
 int IOContextSecure::FSync() { return enc_untrusted_fsync(host_fd_); }
 
 int IOContextSecure::FStat(struct stat *st) {
-  return enc_untrusted_fstat(host_fd_, st);
+  return platform::storage::secure_fstat(host_fd_, st);
 }
 
 int IOContextSecure::Isatty() { return enc_untrusted_isatty(host_fd_); }

--- a/asylo/platform/storage/secure/aead_handler.cc
+++ b/asylo/platform/storage/secure/aead_handler.cc
@@ -937,6 +937,18 @@ const OffsetTranslator &AeadHandler::GetOffsetTranslator() const {
   return *offset_translator_;
 }
 
+off_t AeadHandler::GetLogicalFileSize(int fd) {
+  absl::MutexLock global_lock(&mu_);
+  auto entry = fmap_.find(fd);
+  if (entry == fmap_.end()) {
+    LOG(ERROR)
+        << "Attempt made to get logical file size on an unopened file, fd = "
+        << fd;
+    return -1;
+  }
+  return entry->second->logical_size;
+}
+
 }  // namespace storage
 }  // namespace platform
 }  // namespace asylo

--- a/asylo/platform/storage/secure/aead_handler.h
+++ b/asylo/platform/storage/secure/aead_handler.h
@@ -101,6 +101,9 @@ class AeadHandler {
   int SetMasterKey(int fd, const uint8_t *key_data, uint32_t key_length)
       LOCKS_EXCLUDED(mu_);
 
+  // Returns the logical file size, or -1 on failure.
+  off_t GetLogicalFileSize(int fd) LOCKS_EXCLUDED(mu_);
+
   const OffsetTranslator &GetOffsetTranslator() const;
 
  private:

--- a/asylo/platform/storage/secure/enclave_storage_secure.h
+++ b/asylo/platform/storage/secure/enclave_storage_secure.h
@@ -23,6 +23,7 @@
 // invoked via POSIX IO API in the enclave environment. Assures authentication
 // and confidentiality of stored data, backed by AE.
 
+#include <sys/stat.h>
 // IO syscall interface types.
 #include <sys/types.h>
 
@@ -45,6 +46,9 @@ ssize_t secure_write(int fd, const void *buf, size_t count);
 int secure_close(int fd);
 
 off_t secure_lseek(int fd, off_t offset, int whence);
+
+// |st->st_size| will be set to logical file size on success.
+int secure_fstat(int fd, struct stat* st);
 
 }  // namespace storage
 }  // namespace platform


### PR DESCRIPTION
Current secure_lseek(fd, 0, SEEK_END) returns incorrect offset due to the
alignment of cipher block size. This commit also makes fstat return
logical file size on securely opened fd.