### PR TITLE
Make __sa_family_t same as host side.

### DIFF
--- a/asylo/distrib/toolchain/newlib-2.5.0.20170922.patch
+++ b/asylo/distrib/toolchain/newlib-2.5.0.20170922.patch
@@ -10039,7 +10039,7 @@ diff -Naur ../newlib-2.5.0.20170922/newlib/libc/sys/enclave/include/limits.h ./n
 diff -Naur ../newlib-2.5.0.20170922/newlib/libc/sys/enclave/include/machine/_types.h ./newlib/libc/sys/enclave/include/machine/_types.h
 --- ../newlib-2.5.0.20170922/newlib/libc/sys/enclave/include/machine/_types.h
 +++ ./newlib/libc/sys/enclave/include/machine/_types.h
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,45 @@
 +#ifndef _MACHINE__TYPES_H
 +#define _MACHINE__TYPES_H
 +
@@ -10074,6 +10074,11 @@ diff -Naur ../newlib-2.5.0.20170922/newlib/libc/sys/enclave/include/machine/_typ
 +#define __machine_nlink_t_defined
 +typedef __uint64_t __nlink_t;
 +#endif  // __machine_nlink_t_defined
++
++#ifndef __machine_sa_family_t_defined
++#define __machine_sa_family_t_defined
++typedef __uint16_t __sa_family_t;
++#endif  // __machine_sa_family_t_defined
 +
 +#define __TM_GMTOFF tm_gmtoff
 +#define __TM_ZONE   tm_zone


### PR DESCRIPTION
Currently, sizeof(struct sockaddr_in) mismatch host side due to
__sa_family_t is defined as uint16 in host. But in newlib, it is
defined as uint8 by default.
This will cause potential memory corruption.

--
I was migrating xgboost and got a stack corruption in https://github.com/dmlc/rabit/blob/master/src/socket.h#L76
```
 memcpy(&addr, res->ai_addr, res->ai_addrlen);
```
The sizeof(sockaddr_in) is 16 in host side. But in asylo it is 15.